### PR TITLE
Add service and function level `package.include` capability and simplify bundling process

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -47,7 +47,7 @@ module.exports = {
           this.serverless.cli.log(`Zipping ${outputDir} to ${finalZipFilePath}`);
         }
 
-        return zipDir(outputDir, finalZipFilePath);
+        return zipDir(outputDir, finalZipFilePath, functionBrowserifyConfig.include);
       })
       .then((sizeBytes)=> {
         const fileSizeInMegabytes = sizeBytes / 1000000.0;
@@ -64,7 +64,7 @@ module.exports = {
   },
 };
 
-function zipDir(dirPath, destZipFilePath) {
+function zipDir(dirPath, destZipFilePath, include) {
   return new BbPromise((resolve, reject) => {
     let output  = fs.createWriteStream(destZipFilePath);
     let archive = archiver.create('zip');
@@ -76,9 +76,11 @@ function zipDir(dirPath, destZipFilePath) {
     archive.on('error', (err) => reject(err));
 
     archive.pipe(output);
-    archive
-      .append('empty so lambda inline editor does not show', {name: 'empty.txt'})
-      .directory(dirPath, '')
-      .finalize();
+    archive.append('empty so lambda inline editor does not show', {
+      name: 'empty.txt'
+    });
+    archive.directory(dirPath, '');
+    include.forEach(glob => archive.glob(glob));
+    archive.finalize();
   });
 }

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -80,7 +80,9 @@ function zipDir(dirPath, destZipFilePath, include) {
       name: 'empty.txt'
     });
     archive.directory(dirPath, '');
-    include.forEach(glob => archive.glob(glob));
+    if (include) {
+      include.forEach(glob => archive.glob(glob));
+    }
     archive.finalize();
   });
 }

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -5,7 +5,6 @@ const BbPromise  = require('bluebird'),
       browserify = require('browserify'),
       path       = require('path'),
       fs         = BbPromise.promisifyAll(require('fs-extra')),
-      _          = require('lodash'),
       archiver   = require('archiver');
 
 module.exports = {
@@ -34,22 +33,23 @@ module.exports = {
           return reject(err);
         }
 
-        const handlerPath = path.join(outputDir, functionObject.handler.split('.')[0] + '.js');
+        functionObject.handler = path.basename(functionObject.handler);
+        const handlerName = functionObject.handler.split('.')[0];
+        const handlerPath = path.join(outputDir, handlerName + '.js');
 
-        fs.mkdirSync(path.dirname(handlerPath), '0777');  //handler may be in a subdir
-        fs.writeFile(handlerPath, bundledBuf, (err)=> {
+        fs.writeFile(handlerPath, bundledBuf, (err) => {
           (err) ? reject(err) : resolve();
         });
       });
     })
-      .then(()=> {
+      .then(() => {
         if (process.env.SLS_DEBUG) {
           this.serverless.cli.log(`Zipping ${outputDir} to ${finalZipFilePath}`);
         }
 
         return zipDir(outputDir, finalZipFilePath, functionBrowserifyConfig.include);
       })
-      .then((sizeBytes)=> {
+      .then((sizeBytes) => {
         const fileSizeInMegabytes = sizeBytes / 1000000.0;
         this.serverless.cli.log(`Created ${functionName}.zip (${Math.round(fileSizeInMegabytes * 100) / 100} MB)...`);
 
@@ -61,7 +61,7 @@ module.exports = {
         //@see https://serverless.com/framework/docs/providers/aws/guide/packaging/#artifact
         functionObject.package.artifact = finalZipFilePath;
       });
-  },
+  }
 };
 
 function zipDir(dirPath, destZipFilePath, include) {
@@ -69,19 +69,13 @@ function zipDir(dirPath, destZipFilePath, include) {
     let output  = fs.createWriteStream(destZipFilePath);
     let archive = archiver.create('zip');
 
-    output.on('close', () => {
-      resolve(archive.pointer());
-    });
-
+    output.on('close', () => resolve(archive.pointer()));
     archive.on('error', (err) => reject(err));
 
     archive.pipe(output);
-    archive.append('empty so lambda inline editor does not show', {
-      name: 'empty.txt'
-    });
     archive.directory(dirPath, '');
-    if (include) {
-      include.forEach(glob => archive.glob(glob));
+    if (include && include.length) {
+      include.forEach((glob) => archive.glob(glob));
     }
     archive.finalize();
   });

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const xtend = require('xtend'),
-      _     = require('lodash');
+      union = require('lodash.union');
 
 module.exports = {
   /**
@@ -46,7 +46,7 @@ module.exports = {
     if (this.serverless.service.package) {
       //Merge together package.exclude and custom.browserify.exclude
       if (this.serverless.service.package.exclude && this.serverless.service.package.exclude.length) {
-        this.globalBrowserifyConfig.exclude = _.union(this.serverless.service.package.exclude, this.globalBrowserifyConfig.exclude);
+        this.globalBrowserifyConfig.exclude = union(this.serverless.service.package.exclude, this.globalBrowserifyConfig.exclude);
       }
       //Save service package.include
       if (this.serverless.service.package.include && this.serverless.service.package.include.length) {
@@ -85,11 +85,11 @@ module.exports = {
     if (functionObject.package) {
       //Merge together functions.FUNCTION.package.exclude and browserify exclude
       if (functionObject.package.exclude && functionObject.package.exclude.length) {
-        functionBrowserifyConfig.exclude = _.union(functionBrowserifyConfig.exclude, functionObject.package.exclude);
+        functionBrowserifyConfig.exclude = union(functionBrowserifyConfig.exclude, functionObject.package.exclude);
       }
       //Merge together service and function includes
       if (functionObject.package.include && functionObject.package.include.length) {
-        functionBrowserifyConfig.include = _.union(functionBrowserifyConfig.include, functionObject.package.include);
+        functionBrowserifyConfig.include = union(functionBrowserifyConfig.include, functionObject.package.include);
       }
     }
 
@@ -98,5 +98,5 @@ module.exports = {
     }
 
     return functionBrowserifyConfig;
-  },
+  }
 };

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -43,10 +43,14 @@ module.exports = {
     //Merge in global config
     this.globalBrowserifyConfig = xtend(globalDefault, globalCustom);
 
-    //Merge together package.exclude and custom.browserify.exclude
     if (this.serverless.service.package) {
+      //Merge together package.exclude and custom.browserify.exclude
       if (this.serverless.service.package.exclude && this.serverless.service.package.exclude.length) {
         this.globalBrowserifyConfig.exclude = _.union(this.serverless.service.package.exclude, this.globalBrowserifyConfig.exclude);
+      }
+      //Save service package.include
+      if (this.serverless.service.package.include && this.serverless.service.package.include.length) {
+          this.globalBrowserifyConfig.include = this.serverless.service.package.include;
       }
     }
 
@@ -82,6 +86,10 @@ module.exports = {
       //Merge together functions.FUNCTION.package.exclude and browserify exclude
       if (functionObject.package.exclude && functionObject.package.exclude.length) {
         functionBrowserifyConfig.exclude = _.union(functionBrowserifyConfig.exclude, functionObject.package.exclude);
+      }
+      //Merge together service and function includes
+      if (functionObject.package.include && functionObject.package.include.length) {
+        functionBrowserifyConfig.include = _.union(functionBrowserifyConfig.include, functionObject.package.include);
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "serverless-plugin-browserify",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Serverless v1.0 plugin that uses Browserify to bundle NodeJS Lambda functions.",
   "main": "index.js",
   "author": "Ryan Pendergast <ryan.pendergast@gmail.com> (http://rynop.com)",
+  "contributors": [
+    "Ricardo Nolde <ricardo@nolde.com.br>"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/doapp-ryanp/serverless-plugin-browserify.git"
@@ -25,7 +28,7 @@
     "bluebird": "~3.4.6",
     "browserify": "~13.1.1",
     "fs-extra": "~0.30.0",
-    "lodash": "^4.16.4",
+    "lodash.union": "4.6.0",
     "xtend": "~4.0.1"
   },
   "devDependencies": {}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-browserify",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Serverless v1.0 plugin that uses Browserify to bundle NodeJS Lambda functions.",
   "main": "index.js",
   "author": "Ryan Pendergast <ryan.pendergast@gmail.com> (http://rynop.com)",


### PR DESCRIPTION
This fixes #5 and #9.

When using `googleapis` npm package along with browserify, I get an "ENOENT: no such file or directory, scandir '/apis'" error during execution.

That happens because `googleapis` module requires its internal parts using a programmatic require model, reading the "apis" folder and requesting each separately. As browserify does not interpret the code, just searches for requires and matches the names of dependencies, the behavior is broken.

Therefore, it is important to turn on the `package.include` ability provided by serverless by default, but that is overridden by the plugin.