### PR TITLE
Check the custom object exists first

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -12,7 +12,7 @@ module.exports = {
       this.serverless.cli.log('SlsBrowserify::globalConfig');
     }
 
-    const globalCustom = this.serverless.service.custom.browserify || {};
+    const globalCustom = this.serverless.service.custom && this.serverless.service.custom.browserify || {};
 
     if (globalCustom.disable) {
       throw new this.serverless.classes.Error('custom.browserify.disable is true in serverless.yml', 'skip');


### PR DESCRIPTION
This fixes https://github.com/doapp-ryanp/serverless-plugin-browserify/issues/1