### PR TITLE
Fix issue where `bundle.js` expect empty array for `include` option, instead of `null`

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -21,6 +21,7 @@ module.exports = {
     let globalDefault = {  //Browserify plugin config
       disable: false, //Not an official option, used as internal option to skip browserify
       exclude: [],    //Not an option, but will use for setting browserify.exclude() if defined in yml
+      include: [],    //Not an option, but will use for setting browserify.include() if defined in yml
       ignore:  [],    //Not an option, but will use for setting browserify.ignore() if defined in yml
 
       basedir:          this.serverless.config.servicePath,


### PR DESCRIPTION
## Problem

If `package.include` is not defined in the `serverless.yml`, the following error will be returned:

```
TypeError: Cannot read property 'length' of undefined
    at GlobAll.globNext (/Users/faizhasim/dev/github/serverless-dynamic-dynamodb/node_modules/glob-all/glob-all.js:84:20)
    at GlobAll.run (/Users/faizhasim/dev/github/serverless-dynamic-dynamodb/node_modules/glob-all/glob-all.js:78:8)
    at Function.globAll.sync (/Users/faizhasim/dev/github/serverless-dynamic-dynamodb/node_modules/glob-all/glob-all.js:192:41)
    at BbPromise (/Users/faizhasim/dev/github/serverless-dynamic-dynamodb/node_modules/serverless-plugin-browserify/lib/bundle.js:32:31)
    at SlsBrowserify.bundle (/Users/faizhasim/dev/github/serverless-dynamic-dynamodb/node_modules/serverless-plugin-browserify/lib/bundle.js:31:12)
    at SlsBrowserify.BbPromise.bind.then.then.then (/Users/faizhasim/dev/github/serverless-dynamic-dynamodb/node_modules/serverless-plugin-browserify/index.js:70:26)
From previous event:
    at browserify:validate (/Users/faizhasim/dev/github/serverless-dynamic-dynamodb/node_modules/serverless-plugin-browserify/index.js:70:10)
    at BbPromise.reduce (/Users/faizhasim/dev/github/serverless-dynamic-dynamodb/node_modules/serverless/lib/classes/PluginManager.js:160:50)
    at runCallback (timers.js:651:20)
    at tryOnImmediate (timers.js:624:5)
    at processImmediate [as _immediateCallback] (timers.js:596:5)
From previous event:
    at PluginManager.run (/Users/faizhasim/dev/github/serverless-dynamic-dynamodb/node_modules/serverless/lib/classes/PluginManager.js:160:22)
    at Serverless.run (/Users/faizhasim/dev/github/serverless-dynamic-dynamodb/node_modules/serverless/lib/Serverless.js:91:31)
    at serverless.init.then (/Users/faizhasim/dev/github/serverless-dynamic-dynamodb/node_modules/serverless/bin/serverless:23:50)
    at process._tickCallback (internal/process/next_tick.js:103:7)
```

## Workaround

Workaround is to define `package.include` as folowing:

```yaml
package:
  individually: true
  include:
    - yarn.lock
```

## Fix

This PR is just a simple fix for that.