### PR TITLE
Fix TypeError related to package.include

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -29,12 +29,14 @@ module.exports = {
     functionBrowserifyConfig.ignore.forEach(file => b.ignore(file));
 
     return new BbPromise((resolve, reject) => {
-      let includeFiles = glob.sync(functionBrowserifyConfig.include, {
-        cwd:    this.serverless.config.servicePath,
-        dot:    true,
-        silent: true,
-        follow: true,
-      });
+      let includeFiles = functionBrowserifyConfig.include && functionBrowserifyConfig.include.length 
+        ? glob.sync(functionBrowserifyConfig.include, {
+            cwd:    this.serverless.config.servicePath,
+            dot:    true,
+            silent: true,
+            follow: true,
+          })
+        : [];
 
       if (process.env.SLS_DEBUG) {
         this.serverless.cli.log(`Copying includes: ` + includeFiles);


### PR DESCRIPTION
Fixes "Type Error: Cannot read property 'length' of undefined" issue,
related to the usage of package.include.

Resolves #14