### PR TITLE
Fix deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,11 +30,13 @@ class SlsBrowserify {
           out:      {
             usage:    'Path to output directory',
             shortcut: 'o',
+            type: 'string',
           },
           function: {
             usage:    'Name of the function',
             shortcut: 'f',
             required: true,
+            type: 'string',
           },
         },
         commands:        {},


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
 - SlsBrowserify for "out", "function"
```